### PR TITLE
Force crc output to the full 32 bits, 8 hex characters

### DIFF
--- a/parse_pack.py
+++ b/parse_pack.py
@@ -153,7 +153,7 @@ def parse_folder(target_folder, output_file):
                               filename,
                               sha1.hexdigest(),
                               md5.hexdigest(),
-                              hex(crc & 0xffffffff)[2:],
+                              '{0:08x}'.format(crc & 0xffffffff),
                               sep="\t",
                               file=output_file)
                         i += 1


### PR DESCRIPTION
The hexdigest() functions always return the full bit length of their respective hashes pre-pended with zeros.  The hex() function used to output the crc calculation returns the fewest characters.  This normalizes the crc output so that its the full length, pre-prended with zeros.

An example of this is in the Atari 2600 SMDB where "Snatcher 2600 (2011) (Mr. Podoboo).a26" has a crc of "30d0a".  This change returns "00030d0a".
