### PR TITLE
Add zip support to build_pack

### DIFF
--- a/build_pack.py
+++ b/build_pack.py
@@ -8,6 +8,7 @@ import sys
 import shutil
 import hashlib
 import argparse
+import zipfile
 from collections import defaultdict
 
 
@@ -113,6 +114,20 @@ def copy_file(source, dest):
         copy_fn(source, fixed_dest)
 
 
+def extract_file(filename, entry, method, dest):
+    """
+    extracts entry from archive to given destination directory
+    """
+    if method == 'zip':
+        try:
+            # extract the file to the new directory
+            zipfile.ZipFile(filename).extract(entry, os.path.dirname(dest))
+        except FileNotFoundError:
+            # Windows' default API is limited to paths of 260 characters
+            fixed_dest = u'\\\\?\\' + os.path.abspath(dest)
+            zipfile.ZipFile(filename).extract(entry, os.path.dirname(fixed_dest))
+
+
 def parse_database(target_database):
     """
     store hash values and filenames in a database.
@@ -121,10 +136,10 @@ def parse_database(target_database):
     number_of_entries = 0
     with open(target_database, "r") as target_database:
         for line in target_database:
-            hash_value, filename, other_hash = line.strip().split("\t", 2)
+            hash_sha256, filename, _, _, hash_crc = line.strip().split("\t", 4)
             number_of_entries += 1
-            db[hash_value].append(filename)
-
+            db[hash_sha256].append(filename)
+            db[hash_crc].append(filename)
     return db, number_of_entries
 
 
@@ -147,42 +162,81 @@ def parse_folder(source_folder, db, output_folder):
             for f in filenames:
                 filename = os.path.join(os.path.normpath(dirpath), f)
                 absolute_filename = u'\\\\?\\' + os.path.abspath(filename)
-                h = hashlib.sha256()
                 try:
-                    with open(filename, "rb", buffering=0) as f:
-                        # use a small buffer to compute hash to
-                        # avoid memory overload
-                        for b in iter(lambda: f.read(128 * 1024), b''):
-                            h.update(b)
+                    hashes = get_hashes(filename)
                 except FileNotFoundError:
-                    with open(absolute_filename, "rb", buffering=0) as f:
-                        # use a small buffer to compute hash to
-                        # avoid memory overload
-                        for b in iter(lambda: f.read(128 * 1024), b''):
-                            h.update(b)
-                if h.hexdigest() in db:
-                    # we have a hit
-                    for entry in db[h.hexdigest()]:
-                        found_entries += 1
-                        new_path = os.path.join(output_folder,
-                                                os.path.dirname(entry))
-                        # create directory structure if need be
-                        if not os.path.exists(new_path):
-                            os.makedirs(new_path, exist_ok=True)
-                        new_file = os.path.join(output_folder, entry)
-                        if (not ARGS.skip_existing or not
-                                os.path.exists(new_file)):
-                            # copy the file to the new directory
-                            copy_file(filename, new_file)
-                    # remove the hit from the database
-                    del db[h.hexdigest()]
-                i += 1
-                print_progress(i, END_LINE)
+                    hashes = get_hashes(absolute_filename)
+
+                for h, info in hashes.items():
+                    if h in db:
+                        # we have a hit
+                        for entry in db[h]:
+                            found_entries += 1
+                            new_path = os.path.join(output_folder,
+                                                    os.path.dirname(entry))
+                            # create directory structure if need be
+                            if not os.path.exists(new_path):
+                                os.makedirs(new_path, exist_ok=True)
+                            new_file = os.path.join(output_folder, entry)
+                            if (not ARGS.skip_existing or not
+                                    os.path.exists(new_file)):
+                                if info['archive']:
+                                    # extract file from archive to directory
+                                    extract_file(info['filename'],
+                                                 info['archive']['entry'],
+                                                 info['archive']['type'],
+                                                 new_file)
+                                else:
+                                    # copy the file to the new directory
+                                    copy_file(info['filename'], new_file)
+                        # remove the hit from the database
+                        del db[h]
+
+                    i += 1
+                    print_progress(i, END_LINE)
     else:
         if not ARGS.new_line:
             print_progress(i, "\n")
 
     return found_entries
+
+
+def get_hashes(filename):
+    """
+    return dictionary of hashes containing:
+        - sha256 hash of the file itself
+        - additional hashes if the file is a compressed archive
+    """
+    hashes = {}
+    h = hashlib.sha256()
+
+    # hash the file itself
+    with open(filename, "rb", buffering=0) as f:
+        # use a small buffer to compute hash to
+        # avoid memory overload
+        for b in iter(lambda: f.read(128 * 1024), b''):
+            h.update(b)
+
+    # add file hash to dict
+    hashes[h.hexdigest()] = {
+        'filename': filename,
+        'archive': None
+    }
+
+    # if this is a zipfile, extract CRCs from header
+    if zipfile.is_zipfile(filename):
+        with zipfile.ZipFile(filename, 'r') as z:
+            for info in z.infolist():
+                # add archive entry hash to dict
+                hashes[hex(info.CRC).lstrip('0x')] = {
+                    'filename': filename,
+                    'archive': {
+                        'entry': info.filename,
+                        'type': 'zip'
+                    }
+                }
+
+    return hashes
 
 
 # *********************************************************************#


### PR DESCRIPTION
* zip headers only include the CRC hash, so we can only use that unless
  we decompress the file, which would be too slow.
* Rather than simply comparing a hash against the hash database, we need to
  create a dictionary of hashes:
    * If we are hashing the file itself, then we just have the file's
      name with the "archive" dict set to None
    * If we are storing hashes of entries located within a compressed
      archive, we need to store the archive name, the file within the
      archive, and the compression format. This will make it more
      straight forward to extract later if it's a "hit"
* It should be possible to support other archive types using the same
  data structures (assuming the file format stores a compatible hash
  type)
* This will work on zip files with a single ROM within them as well as
  zips with lots of ROMs within them. You can store your entire collection in
  a single zip and build_pack will produce the same result as if they were
  all individual files on your drive.