### PR TITLE
Rename file after extracting from zip

### DIFF
--- a/build_pack.py
+++ b/build_pack.py
@@ -123,6 +123,9 @@ def extract_file(filename, entry, method, dest):
         try:
             # extract the file to the new directory
             zipfile.ZipFile(filename).extract(entry, os.path.dirname(dest))
+            filename = os.path.join(os.path.dirname(dest), entry)
+            if filename != dest:
+                os.replace(filename, dest)
         except FileNotFoundError:
             # Windows' default API is limited to paths of 260 characters
             fixed_dest = u'\\\\?\\' + os.path.abspath(dest)


### PR DESCRIPTION
I found that some .zip files contained the right file based on the CRC value, but weren't necessarily named correctly and were extracted as-is. This PR renames the file post-extraction if it doesn't match the filename in the SMDB.txt.