### PR TITLE
Fix issue when getting absolute filename

### DIFF
--- a/parse_pack.py
+++ b/parse_pack.py
@@ -106,7 +106,6 @@ def parse_folder(target_folder, output_file):
                 filenames.sort()
                 for f in filenames:
                     filename = os.path.join(os.path.normpath(dirpath), f)
-                    filename = filename.lstrip("/")  # /root/a/b to root/a/b
                     absolute_filename = os.path.abspath(filename)
                     os.path.isfile(absolute_filename)
                     # convert to Unix format by default


### PR DESCRIPTION
Fixes this example of bug:

```
$ python parse_pack.py -f ~/Desktop/SmokeMonster-Packs/EverDrive\ N8/ -o test.txt
Traceback (most recent call last):
  File "parse_pack.py", line 131, in parse_folder
    buffering=0) as f:
FileNotFoundError: [Errno 2] No such file or directory: '/home/legerf/workspace/EverDrive-Packs-Lists-Database/home/legerf/Desktop/SmokeMonster-Packs/EverDrive N8/1 US - A-F/10-Yard Fight (USA, Europe).nes'
```