### PR TITLE
Fix pack building zipfile CRC hashes

### DIFF
--- a/build_pack.py
+++ b/build_pack.py
@@ -231,7 +231,8 @@ def get_hashes(filename):
             with zipfile.ZipFile(filename, 'r') as z:
                 for info in z.infolist():
                     # add archive entry hash to dict
-                    hashes[hex(info.CRC).lstrip('0x')] = {
+                    crc_formatted_hex = '{0:08x}'.format(info.CRC & 0xffffffff)
+                    hashes[crc_formatted_hex] = {
                         'filename': filename,
                         'archive': {
                             'entry': info.filename,


### PR DESCRIPTION
I found that there's a mismatch between the pack building and parsing scripts when it comes to CRC digit length. Databases created by the pack parsing script will always have 8 hex digit CRCs due to 60712698157b3e1a270ce227aa02a89b7b76e9a4, however, the pack building script was not forcing zipfile header CRCs to 8 hex digits.