### PR TITLE
Fix UnicodeDecodeError crash

### DIFF
--- a/build_pack.py
+++ b/build_pack.py
@@ -240,6 +240,8 @@ def get_hashes(filename):
                     }
         except OSError:  # normal file containing a zip magic number?
             pass
+        except UnicodeDecodeError:
+            pass
 
     return hashes
 


### PR DESCRIPTION
I was getting the following error when running `build_pack.py`:
> UnicodeDecodeError: 'utf-8' codec can't decode byte 0x83 in position 0: invalid start byte

I'm not sure what a proper fix would be for this but it seemed pretty reasonable to just `pass` when that error occurs as I believe this will just skip over the file with the erroneous name and there's already a try/catch block there doing the same for an `OSError`