### PR TITLE
fix unicode decode error on falsely detected zip files

### DIFF
--- a/build_pack.py
+++ b/build_pack.py
@@ -240,6 +240,9 @@ def get_hashes(filename):
                     }
         except OSError:  # normal file containing a zip magic number?
             pass
+        except UnicodeDecodeError:
+            print(f'error parsing {filename} as a zip archive\nunable to determine encoding of contained filenames\nif this file is not a zip archive, you may safely ignore this error')
+            pass
 
     return hashes
 


### PR DESCRIPTION
Similar to issue #120, the zipfile package can throw a Unicode decode error if a file is detected as a zipfile but is not and has invalid utf-8 characters in the filename of what it thinks are the component files.  Since this can also occur with a real zip file if the archive advertises the wrong encoding, this patch prints a message to the console with the name of the file that triggered the error, informing the user to ignore the error if the file is not a zip file.  From what I was able to find, if an archive advertises the wrong encoding, the correct encoding has to be provided manually, which does not seem feasible, so in this case, the file will simply be ignored.