### PR TITLE
Correction for detecting bad zip file

### DIFF
--- a/build_pack.py
+++ b/build_pack.py
@@ -238,7 +238,7 @@ def get_hashes(filename):
                             'type': 'zip'
                         }
                     }
-        except OSError:  # normal file containing a zip magic number?
+        except zipfile.BadZipfile:  # normal file containing a zip magic number?
             pass
 
     return hashes


### PR DESCRIPTION
If a file is detected as a zip file using zipfile.is_zipfile, but it's not actually a zip file, it generates an uncaught exception:

```
Traceback (most recent call last):
  File "build_pack.py", line 231, in get_hashes
    with zipfile.ZipFile(filename, 'r') as z:
  File "/usr/lib/python3.7/zipfile.py", line 1222, in __init__
    self._RealGetContents()
  File "/usr/lib/python3.7/zipfile.py", line 1317, in _RealGetContents
    raise BadZipFile("Bad magic number for central directory")
zipfile.BadZipFile: Bad magic number for central directory

```

This is because the try/except is looking for an OSError, but what is actually generated is zipfile.BadZipFile.

Corrected the try/except to look for zipfile.BadZipFile to skip files like this.