### PR TITLE
Added "smart" file_strategy option

### DIFF
--- a/build_pack.py
+++ b/build_pack.py
@@ -125,6 +125,13 @@ def copy_file(source, dest, original):
         # Windows' default API is limited to paths of 260 characters
         fixed_dest = u'\\\\?\\' + os.path.abspath(dest)
         copy_fn(source, fixed_dest)
+    except OSError:
+        try:
+            shutil.copyfile(source, dest)
+        except FileNotFoundError:
+            # Windows' default API is limited to paths of 260 characters
+            fixed_dest = u'\\\\?\\' + os.path.abspath(dest)
+            shutil.copyfile(source, fixed_dest)
 
 
 def extract_file(filename, entry, method, dest):


### PR DESCRIPTION
Fixed a couple annoying behaviors I'd seen: zipfile.BadZipFile exception and a habit of creating empty directories when extracting files from zips.

I also added a new function: --file_strategy smart

What this does is copy over the first instance of a file as normal. However, any subsequent copy will be hardlinked from that original source. This would save on space when building a pack to another disk that could use hardlinks. Since the links reference a file on the same target, this would dramatically save on space. For instance, the SD2SNES pack right now weighs in at 25.4 GB, but using "smart" (I couldnt come up with another name...feel free to change it) it only takes up 15 GB of real space. I've tested this on ext4, ntfs, and exfat (it just copies on exfat since it generates an OSError exception and I caught that).

This should also make it possible to create CD based Game Series Collections without using up a ton of space.