### PR TITLE
Prevent files in zips from clobbering other files in output directory. Fix shadowing `filename` variable.

### DIFF
--- a/build_pack.py
+++ b/build_pack.py
@@ -197,9 +197,13 @@ def extract_file(filename, entry, method, dest):
         # extracted from a zip file
         with zipfile.ZipFile(filename) as zip_file:
             for member in zip_file.namelist():
-                filename = os.path.basename(member)
+                # skip other files in the zip
+                if member != entry:
+                    continue
+
+                basename = os.path.basename(member)
                 # skip directories
-                if not filename:
+                if not basename:
                     continue
 
                 # copy file (taken from zipfile's extract)


### PR DESCRIPTION
This should fix https://github.com/SmokeMonsterPacks/EverDrive-Packs-Lists-Database/issues/520.